### PR TITLE
Updated master server listings

### DIFF
--- a/dist.linux/System/UnrealTournament.ini
+++ b/dist.linux/System/UnrealTournament.ini
@@ -63,8 +63,23 @@ UseSound=True
 ServerActors=IpDrv.UdpBeacon
 ServerActors=IpServer.UdpServerQuery
 ServerActors=IpServer.UdpServerUplink MasterServerAddress=unreal.epicgames.com MasterServerPort=27900
-ServerActors=IpServer.UdpServerUplink MasterServerAddress=master0.gamespy.com MasterServerPort=27900
-ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.mplayer.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=utmaster.epicgames.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.newbiesplayground.net MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.errorist.eu MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.333networks.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.errorist.eu MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.oldunreal.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master2.oldunreal.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.hypercoop.tk MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.openspy.net MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.gonespy.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.frag-net.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master-uk.unrealarchive.org MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master-de.unrealarchive.org MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.qtracker.com MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.hlkclan.net MasterServerPort=27900
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master.telefragged.com MasterServerPort=27500
+ServerActors=IpServer.UdpServerUplink MasterServerAddress=master2.qtracker.com MasterServerPort=27900
 ServerActors=UWeb.WebServer
 ServerPackages=SoldierSkins
 ServerPackages=CommandoSkins
@@ -424,6 +439,7 @@ ServerListNames[16]=None
 ServerListNames[17]=None
 ServerListNames[18]=None
 ServerListNames[19]=None
+bKeepMasterServer=True
 
 [UBrowserUT]
 ListFactories[0]=UBrowser.UBrowserSubsetFact,SupersetTag=UBrowserAll,bCompatibleServersOnly=True
@@ -456,10 +472,26 @@ ListFactories[0]=UBrowser.UBrowserSubsetFact,SupersetTag=UBrowserAll,GameType=As
 ListFactories[0]=UBrowser.UBrowserSubsetFact,SupersetTag=UBrowserAll,GameType=LastManStanding,bCompatibleServersOnly=True
 
 [UBrowserAll]
-ListFactories[0]=UBrowser.UBrowserGSpyFact,MasterServerAddress=unreal.epicgames.com,MasterServerTCPPort=28900,Region=0,GameName=ut
-ListFactories[1]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master0.gamespy.com,MasterServerTCPPort=28900,Region=0,GameName=ut
+ListFactories[0]=UBrowser.UBrowserHTTPFact,MasterServerAddress=lists.gameserverlister.com,MasterServerTCPPort=80,MasterServerURI=/ut-servers.txt
+ListFactories[1]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.333networks.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[2]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.oldunreal.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[3]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.errorist.eu,MasterServerTCPPort=28900,GameName=ut
+ListFactories[4]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.hypercoop.tk,MasterServerTCPPort=28900,GameName=ut
+ListFactories[5]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.openspy.net,MasterServerTCPPort=28900,GameName=ut
+ListFactories[6]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master2.qtracker.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[7]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.newbiesplayground.net,MasterServerTCPPort=28900,GameName=ut
+ListFactories[8]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.frag-net.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[9]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master-uk.unrealarchive.org,MasterServerTCPPort=28900,GameName=ut
+ListFactories[10]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master-de.unrealarchive.org,MasterServerTCPPort=28900,GameName=ut
+ListFactories[11]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.gonespy.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[12]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.hlkclan.net,MasterServerTCPPort=28900,GameName=ut
+ListFactories[13]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.telefragged.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[14]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.qtracker.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[15]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master2.oldunreal.com,MasterServerTCPPort=28900,GameName=ut
+ListFactories[16]=UBrowser.UBrowserGSpyFact,MasterServerAddress=master.errorist.eu,MasterServerTCPPort=28900,Region=0,GameName=ut
+bFallbackFactories=False
 bHidden=True
-bFallbackFactories=True
+
 
 [UTMenu.UTMultiplayerMenu]
 OnlineServices[0]=LOCALIZE,MPlayer


### PR DESCRIPTION
Added new master server listings to account for official server shutdown. Included server listings from oldunreal and 333networks.

https://www.oldunreal.com/wiki/index.php?title=Masterserver_Guide https://333networks.com/instructions/ut/c